### PR TITLE
Type-safe project accessors

### DIFF
--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -72,7 +72,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation(project(":common"))
+    implementation(projects.common)
 
     implementation(libs.firebase.analytics)
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,3 +7,4 @@ pluginManagement {
 }
 
 enableFeaturePreview("VERSION_CATALOGS")
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/wearos/build.gradle.kts
+++ b/wearos/build.gradle.kts
@@ -66,7 +66,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation(project(":common"))
+    implementation(projects.common)
 
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)


### PR DESCRIPTION
Make use of Gradle 7.0 type-safe project accessors