### PR TITLE
Start making use of capabilities

### DIFF
--- a/changelogs/whatsnew-en-GB
+++ b/changelogs/whatsnew-en-GB
@@ -2,3 +2,4 @@ Changes:
 When donating, a progress indicator will show while we're connecting to Google Play
 Widgets will now launch the app when tapped
 We made some improvements to the DnD Sync backend. This includes fixing Sync with Theater Mode
+We've started checking your watches capabilities, instead of allowing access to features that won't work

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsActivity.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsActivity.kt
@@ -13,9 +13,11 @@ import androidx.compose.runtime.remember
 import com.boswelja.smartwatchextensions.common.ui.AppTheme
 import com.boswelja.smartwatchextensions.common.ui.UpNavigationWatchPickerAppBar
 import com.boswelja.smartwatchextensions.watchmanager.WatchManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 class BatterySyncSettingsActivity : AppCompatActivity() {
 
+    @ExperimentalCoroutinesApi
     @ExperimentalMaterialApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsScreen.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsScreen.kt
@@ -25,15 +25,21 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 @ExperimentalMaterialApi
 @Composable
 fun BatterySyncSettingsScreen() {
+    val viewModel: BatterySyncViewModel = viewModel()
+    val batterySyncEnabled by viewModel.batterySyncEnabled.collectAsState(false)
     val scrollState = rememberScrollState()
     Column(
         Modifier.verticalScroll(scrollState)
     ) {
         BatterySyncSettings()
         Divider()
-        ChargeNotificationSettings()
+        ChargeNotificationSettings(
+            isEnabled = batterySyncEnabled
+        )
         Divider()
-        LowBatteryNotificationSettings()
+        LowBatteryNotificationSettings(
+            isEnabled = batterySyncEnabled
+        )
     }
 }
 

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsScreen.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsScreen.kt
@@ -19,7 +19,9 @@ import com.boswelja.smartwatchextensions.common.ui.CheckboxPreference
 import com.boswelja.smartwatchextensions.common.ui.HeaderItem
 import com.boswelja.smartwatchextensions.common.ui.SliderPreference
 import com.boswelja.smartwatchextensions.common.ui.SwitchPreference
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@ExperimentalCoroutinesApi
 @ExperimentalMaterialApi
 @Composable
 fun BatterySyncSettingsScreen() {
@@ -35,9 +37,12 @@ fun BatterySyncSettingsScreen() {
     }
 }
 
+@ExperimentalCoroutinesApi
 @ExperimentalMaterialApi
 @Composable
-fun BatterySyncSettings() {
+fun BatterySyncSettings(
+    modifier: Modifier = Modifier
+) {
     val viewModel: BatterySyncViewModel = viewModel()
 
     val batterySyncEnabled by viewModel.batterySyncEnabled.collectAsState(false)
@@ -46,7 +51,7 @@ fun BatterySyncSettings() {
         mutableStateOf(syncInterval / 100f)
     }
 
-    Column {
+    Column(modifier) {
         HeaderItem(stringResource(R.string.category_battery_sync_settings))
         SwitchPreference(
             text = stringResource(R.string.battery_sync_toggle_title),
@@ -60,6 +65,7 @@ fun BatterySyncSettings() {
             value = currentInterval,
             valueRange = 0.15f..0.60f,
             trailingFormat = stringResource(R.string.battery_sync_interval),
+            isEnabled = batterySyncEnabled,
             onSliderValueChanged = {
                 currentInterval = it
             },
@@ -70,9 +76,13 @@ fun BatterySyncSettings() {
     }
 }
 
+@ExperimentalCoroutinesApi
 @ExperimentalMaterialApi
 @Composable
-fun ChargeNotificationSettings() {
+fun ChargeNotificationSettings(
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true
+) {
     val viewModel: BatterySyncViewModel = viewModel()
 
     val phoneChargeNotiEnabled by viewModel.phoneChargeNotiEnabled.collectAsState(false)
@@ -82,7 +92,7 @@ fun ChargeNotificationSettings() {
         mutableStateOf(chargeThreshold / 100f)
     }
 
-    Column {
+    Column(modifier) {
         HeaderItem(stringResource(R.string.category_charge_notifications))
         CheckboxPreference(
             text = stringResource(R.string.battery_sync_phone_charge_noti_title),
@@ -91,6 +101,7 @@ fun ChargeNotificationSettings() {
                 (currentThreshold * 100).toInt().toString()
             ),
             isChecked = phoneChargeNotiEnabled,
+            isEnabled = isEnabled,
             onCheckChanged = {
                 viewModel.setPhoneChargeNotiEnabled(it)
             }
@@ -102,6 +113,7 @@ fun ChargeNotificationSettings() {
                 (currentThreshold * 100).toInt().toString()
             ),
             isChecked = watchChargeNotiEnabled,
+            isEnabled = isEnabled,
             onCheckChanged = {
                 viewModel.setWatchChargeNotiEnabled(it)
             }
@@ -110,6 +122,7 @@ fun ChargeNotificationSettings() {
             text = stringResource(R.string.battery_sync_charge_threshold_title),
             valueRange = 0.6f..1f,
             value = currentThreshold,
+            isEnabled = isEnabled,
             trailingFormat = stringResource(R.string.battery_percent),
             onSliderValueChanged = {
                 currentThreshold = it
@@ -121,9 +134,13 @@ fun ChargeNotificationSettings() {
     }
 }
 
+@ExperimentalCoroutinesApi
 @ExperimentalMaterialApi
 @Composable
-fun LowBatteryNotificationSettings() {
+fun LowBatteryNotificationSettings(
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true
+) {
     val viewModel: BatterySyncViewModel = viewModel()
 
     val phoneLowNotiEnabled by viewModel.phoneLowNotiEnabled.collectAsState(false)
@@ -133,7 +150,7 @@ fun LowBatteryNotificationSettings() {
         mutableStateOf(batteryLowThreshold / 100f)
     }
 
-    Column {
+    Column(modifier) {
         HeaderItem(stringResource(R.string.category_low_notifications))
         CheckboxPreference(
             text = stringResource(R.string.battery_sync_phone_low_noti_title),
@@ -141,6 +158,7 @@ fun LowBatteryNotificationSettings() {
                 R.string.battery_sync_phone_low_noti_summary,
                 (currentThreshold * 100).toInt().toString()
             ),
+            isEnabled = isEnabled,
             isChecked = phoneLowNotiEnabled,
             onCheckChanged = {
                 viewModel.setPhoneLowNotiEnabled(it)
@@ -152,6 +170,7 @@ fun LowBatteryNotificationSettings() {
                 R.string.battery_sync_watch_low_noti_summary,
                 (currentThreshold * 100).toInt().toString()
             ),
+            isEnabled = isEnabled,
             isChecked = watchLowNotiEnabled,
             onCheckChanged = {
                 viewModel.setWatchLowNotiEnabled(it)
@@ -161,6 +180,7 @@ fun LowBatteryNotificationSettings() {
             text = stringResource(R.string.battery_sync_low_threshold_title),
             valueRange = 0.05f..0.35f,
             value = currentThreshold,
+            isEnabled = isEnabled,
             trailingFormat = stringResource(R.string.battery_percent),
             onSliderValueChanged = {
                 currentThreshold = it

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsScreen.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsScreen.kt
@@ -51,6 +51,7 @@ fun BatterySyncSettings(
 ) {
     val viewModel: BatterySyncViewModel = viewModel()
 
+    val canSyncBattery by viewModel.canSyncBattery.collectAsState(false)
     val batterySyncEnabled by viewModel.batterySyncEnabled.collectAsState(false)
     val syncInterval by viewModel.syncInterval.collectAsState(15)
     var currentInterval by remember {
@@ -61,10 +62,14 @@ fun BatterySyncSettings(
         HeaderItem(stringResource(R.string.category_battery_sync_settings))
         SwitchPreference(
             text = stringResource(R.string.battery_sync_toggle_title),
+            secondaryText = if (!canSyncBattery)
+                stringResource(R.string.capability_not_supported)
+            else null,
             isChecked = batterySyncEnabled,
             onCheckChanged = {
                 viewModel.setBatterySyncEnabled(it)
-            }
+            },
+            isEnabled = canSyncBattery
         )
         SliderPreference(
             text = stringResource(R.string.battery_sync_interval_title),

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
@@ -52,7 +52,7 @@ class BatterySyncViewModel internal constructor(
     val watchLowNotiEnabled = watchManager.getBoolSetting(BATTERY_WATCH_LOW_NOTI_KEY)
     val batteryLowThreshold = watchManager.getIntSetting(BATTERY_LOW_THRESHOLD_KEY)
 
-    val canSyncBattery = watchManager.getCapabilitesForSelectedWatch().mapLatest { capabilities ->
+    val canSyncBattery = watchManager.selectedWatchCapabilities().mapLatest { capabilities ->
         capabilities?.contains(Capability.SYNC_BATTERY.name) == true
     }
 

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
@@ -53,7 +53,7 @@ class BatterySyncViewModel internal constructor(
     val batteryLowThreshold = watchManager.getIntSetting(BATTERY_LOW_THRESHOLD_KEY)
 
     val canSyncBattery = watchManager.selectedWatchCapabilities().mapLatest { capabilities ->
-        capabilities?.contains(Capability.SYNC_BATTERY.name) == true
+        capabilities.contains(Capability.SYNC_BATTERY)
     }
 
     val batteryStats = watchManager.selectedWatch.switchMap {

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.boswelja.smartwatchextensions.batterysync.BatterySyncWorker
 import com.boswelja.smartwatchextensions.batterysync.Utils.updateBatteryStats
 import com.boswelja.smartwatchextensions.batterysync.database.WatchBatteryStatsDatabase
+import com.boswelja.smartwatchextensions.common.connection.Capability
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_CHARGE_THRESHOLD_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_LOW_THRESHOLD_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_PHONE_CHARGE_NOTI_KEY
@@ -21,6 +22,7 @@ import com.boswelja.smartwatchextensions.watchmanager.WatchManager
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -49,6 +51,10 @@ class BatterySyncViewModel internal constructor(
     val phoneLowNotiEnabled = watchManager.getBoolSetting(BATTERY_PHONE_LOW_NOTI_KEY)
     val watchLowNotiEnabled = watchManager.getBoolSetting(BATTERY_WATCH_LOW_NOTI_KEY)
     val batteryLowThreshold = watchManager.getIntSetting(BATTERY_LOW_THRESHOLD_KEY)
+
+    val canSyncBattery = watchManager.getCapabilitesForSelectedWatch().mapLatest { capabilities ->
+        capabilities?.contains(Capability.SYNC_BATTERY.name) == true
+    }
 
     val batteryStats = watchManager.selectedWatch.switchMap {
         it?.let { database.batteryStatsDao().getStats(it.id) }?.asLiveData() ?: liveData { }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/common/ui/Preferences.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/common/ui/Preferences.kt
@@ -36,17 +36,24 @@ fun SwitchPreference(
     text: String,
     secondaryText: String? = null,
     icon: ImageVector? = null,
+    isEnabled: Boolean = true,
     isChecked: Boolean,
     onCheckChanged: (Boolean) -> Unit
 ) {
     ListItem(
-        text = { Text(text) },
+        text = {
+            Text(text = text)
+        },
         secondaryText = if (secondaryText != null) { { Text(secondaryText) } } else null,
         icon = { if (icon != null) { Icon(icon, null) } },
         trailing = {
-            Switch(checked = isChecked, onCheckedChange = null)
+            Switch(
+                checked = isChecked,
+                onCheckedChange = null,
+                enabled = isEnabled
+            )
         },
-        modifier = Modifier.clickable {
+        modifier = Modifier.clickable(enabled = isEnabled) {
             onCheckChanged(!isChecked)
         }
     )
@@ -58,6 +65,7 @@ fun CheckboxPreference(
     text: String,
     secondaryText: String? = null,
     icon: ImageVector? = null,
+    isEnabled: Boolean = true,
     isChecked: Boolean,
     onCheckChanged: (Boolean) -> Unit
 ) {
@@ -66,9 +74,13 @@ fun CheckboxPreference(
         secondaryText = if (secondaryText != null) { { Text(secondaryText) } } else null,
         icon = { if (icon != null) { Icon(icon, null) } },
         trailing = {
-            Checkbox(checked = isChecked, onCheckedChange = null)
+            Checkbox(
+                checked = isChecked,
+                onCheckedChange = null,
+                enabled = isEnabled
+            )
         },
-        modifier = Modifier.clickable {
+        modifier = Modifier.clickable(enabled = isEnabled) {
             onCheckChanged(!isChecked)
         }
     )
@@ -82,6 +94,7 @@ fun SliderPreference(
     valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
     value: Float,
     trailingFormat: String? = null,
+    isEnabled: Boolean = true,
     onSliderValueChanged: (Float) -> Unit,
     onSliderValueFinished: () -> Unit
 ) {
@@ -93,7 +106,8 @@ fun SliderPreference(
                 value = value,
                 valueRange = valueRange,
                 onValueChange = onSliderValueChanged,
-                onValueChangeFinished = onSliderValueFinished
+                onValueChangeFinished = onSliderValueFinished,
+                enabled = isEnabled
             )
         },
         trailing = if (trailingFormat != null) {
@@ -108,6 +122,7 @@ fun <T> DialogPreference(
     text: String,
     secondaryText: String? = null,
     icon: ImageVector? = null,
+    isEnabled: Boolean = true,
     values: Array<Pair<String, T>>,
     value: Pair<String, T>,
     onValueChanged: (Pair<String, T>) -> Unit
@@ -117,7 +132,7 @@ fun <T> DialogPreference(
         text = { Text(text) },
         secondaryText = if (secondaryText != null) { { Text(secondaryText) } } else null,
         icon = { if (icon != null) { Icon(icon, null) } },
-        modifier = Modifier.clickable { dialogVisible = true }
+        modifier = Modifier.clickable(enabled = isEnabled) { dialogVisible = true }
     )
     if (dialogVisible) {
         var selectedValue by remember { mutableStateOf(value) }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsActivity.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsActivity.kt
@@ -10,9 +10,11 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.boswelja.smartwatchextensions.common.ui.AppTheme
 import com.boswelja.smartwatchextensions.common.ui.UpNavigationWatchPickerAppBar
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 class DnDSyncSettingsActivity : AppCompatActivity() {
 
+    @ExperimentalCoroutinesApi
     @ExperimentalMaterialApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsScreen.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsScreen.kt
@@ -74,10 +74,15 @@ fun SyncToWatchSetting(
 ) {
     val context = LocalContext.current
     val dndSyncToWatch by viewModel.syncToWatch.collectAsState(false)
+    val canSyncToWatch by viewModel.canReceiveDnD.collectAsState(false)
     SwitchPreference(
         text = stringResource(R.string.pref_dnd_sync_to_watch_title),
-        secondaryText = stringResource(R.string.pref_dnd_sync_to_watch_summary),
+        secondaryText = if (canSyncToWatch)
+            stringResource(R.string.pref_dnd_sync_to_watch_summary)
+        else
+            stringResource(R.string.capability_not_supported),
         isChecked = dndSyncToWatch,
+        isEnabled = canSyncToWatch,
         onCheckChanged = {
             if (!it) {
                 viewModel.setSyncToWatch(false)
@@ -97,10 +102,15 @@ fun SyncToPhoneSetting(
     onRequestNotificationPolicyAccess: (String) -> Unit
 ) {
     val dndSyncToPhone by viewModel.syncToPhone.collectAsState(false)
+    val canSyncToPhone by viewModel.canSendDnD.collectAsState(false)
     SwitchPreference(
         text = stringResource(R.string.pref_dnd_sync_to_phone_title),
-        secondaryText = stringResource(R.string.pref_dnd_sync_to_phone_summary),
+        secondaryText = if (canSyncToPhone)
+            stringResource(R.string.pref_dnd_sync_to_phone_summary)
+        else
+            stringResource(R.string.capability_not_supported),
         isChecked = dndSyncToPhone,
+        isEnabled = canSyncToPhone,
         onCheckChanged = {
             if ((it && viewModel.hasNotificationPolicyAccess) || !it) {
                 viewModel.setSyncToPhone(it)
@@ -119,10 +129,14 @@ fun SyncWithTheaterSetting(
     onRequestNotificationPolicyAccess: (String) -> Unit
 ) {
     val dndSyncWithTheater by viewModel.syncWithTheater.collectAsState(false)
+    val canSyncWithTheater by viewModel.canSendDnD.collectAsState(false)
     SwitchPreference(
         text = stringResource(R.string.pref_dnd_sync_with_theater_title),
-        secondaryText = stringResource(R.string.pref_dnd_sync_with_theater_summary),
+        secondaryText = if (canSyncWithTheater)
+            stringResource(R.string.pref_dnd_sync_with_theater_summary)
+        else stringResource(R.string.capability_not_supported),
         isChecked = dndSyncWithTheater,
+        isEnabled = canSyncWithTheater,
         onCheckChanged = {
             if ((it && viewModel.hasNotificationPolicyAccess) || !it) {
                 viewModel.setSyncWithTheater(it)

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsScreen.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsScreen.kt
@@ -1,6 +1,5 @@
 package com.boswelja.smartwatchextensions.dndsync.ui
 
-import android.app.NotificationManager
 import android.content.Intent
 import android.provider.Settings
 import android.widget.Toast
@@ -14,33 +13,27 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.core.content.getSystemService
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.boswelja.smartwatchextensions.R
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.DND_SYNC_TO_PHONE_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.DND_SYNC_WITH_THEATER_KEY
 import com.boswelja.smartwatchextensions.common.ui.SwitchPreference
 import com.boswelja.smartwatchextensions.dndsync.ui.helper.DnDSyncHelperActivity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@ExperimentalCoroutinesApi
 @ExperimentalMaterialApi
 @Composable
 fun DnDSyncSettingsScreen() {
     Column {
         val viewModel: DnDSyncSettingsViewModel = viewModel()
         val context = LocalContext.current
-        val notificationManager = remember {
-            context.getSystemService<NotificationManager>()!!
-        }
-
-        val dndSyncToWatch by viewModel.syncToWatch.collectAsState(false)
-        val dndSyncToPhone by viewModel.syncToPhone.collectAsState(false)
-        val dndSyncWithTheater by viewModel.syncWithTheater.collectAsState(false)
 
         var changingKey = remember<String?> { null }
         val notiPolicyAccessLauncher =
             rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
                 changingKey?.let { key ->
-                    if (notificationManager.isNotificationPolicyAccessGranted) {
+                    if (viewModel.hasNotificationPolicyAccess) {
                         when (key) {
                             DND_SYNC_TO_PHONE_KEY -> viewModel.setSyncToPhone(true)
                             DND_SYNC_WITH_THEATER_KEY -> viewModel.setSyncWithTheater(true)
@@ -50,56 +43,92 @@ fun DnDSyncSettingsScreen() {
                 }
             }
 
-        SwitchPreference(
-            text = stringResource(R.string.pref_dnd_sync_to_watch_title),
-            secondaryText = stringResource(R.string.pref_dnd_sync_to_watch_summary),
-            isChecked = dndSyncToWatch,
-            onCheckChanged = {
-                if (!it) {
-                    viewModel.setSyncToWatch(false)
-                } else {
-                    Intent(context, DnDSyncHelperActivity::class.java)
-                        .also { intent -> context.startActivity(intent) }
-                }
-            }
+        val onRequestNotiPolicyAccess = { key: String ->
+            changingKey = key
+            Toast.makeText(
+                context,
+                context.getString(R.string.dnd_sync_request_policy_access_message),
+                Toast.LENGTH_SHORT
+            ).show()
+            notiPolicyAccessLauncher
+                .launch(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
+        }
+
+        SyncToWatchSetting(viewModel = viewModel)
+        SyncToPhoneSetting(
+            viewModel = viewModel,
+            onRequestNotificationPolicyAccess = onRequestNotiPolicyAccess
         )
-        SwitchPreference(
-            text = stringResource(R.string.pref_dnd_sync_to_phone_title),
-            secondaryText = stringResource(R.string.pref_dnd_sync_to_phone_summary),
-            isChecked = dndSyncToPhone,
-            onCheckChanged = {
-                if ((it && notificationManager.isNotificationPolicyAccessGranted) || !it) {
-                    viewModel.setSyncToPhone(it)
-                } else {
-                    changingKey = DND_SYNC_TO_PHONE_KEY
-                    Toast.makeText(
-                        context,
-                        context.getString(R.string.dnd_sync_request_policy_access_message),
-                        Toast.LENGTH_SHORT
-                    ).show()
-                    notiPolicyAccessLauncher
-                        .launch(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
-                }
-            }
-        )
-        SwitchPreference(
-            text = stringResource(R.string.pref_dnd_sync_with_theater_title),
-            secondaryText = stringResource(R.string.pref_dnd_sync_with_theater_summary),
-            isChecked = dndSyncWithTheater,
-            onCheckChanged = {
-                if ((it && notificationManager.isNotificationPolicyAccessGranted) || !it) {
-                    viewModel.setSyncWithTheater(it)
-                } else {
-                    changingKey = DND_SYNC_WITH_THEATER_KEY
-                    Toast.makeText(
-                        context,
-                        context.getString(R.string.dnd_sync_request_policy_access_message),
-                        Toast.LENGTH_SHORT
-                    ).show()
-                    notiPolicyAccessLauncher
-                        .launch(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
-                }
-            }
+        SyncWithTheaterSetting(
+            viewModel = viewModel,
+            onRequestNotificationPolicyAccess = onRequestNotiPolicyAccess
         )
     }
+}
+
+@ExperimentalMaterialApi
+@ExperimentalCoroutinesApi
+@Composable
+fun SyncToWatchSetting(
+    viewModel: DnDSyncSettingsViewModel
+) {
+    val context = LocalContext.current
+    val dndSyncToWatch by viewModel.syncToWatch.collectAsState(false)
+    SwitchPreference(
+        text = stringResource(R.string.pref_dnd_sync_to_watch_title),
+        secondaryText = stringResource(R.string.pref_dnd_sync_to_watch_summary),
+        isChecked = dndSyncToWatch,
+        onCheckChanged = {
+            if (!it) {
+                viewModel.setSyncToWatch(false)
+            } else {
+                Intent(context, DnDSyncHelperActivity::class.java)
+                    .also { intent -> context.startActivity(intent) }
+            }
+        }
+    )
+}
+
+@ExperimentalMaterialApi
+@ExperimentalCoroutinesApi
+@Composable
+fun SyncToPhoneSetting(
+    viewModel: DnDSyncSettingsViewModel,
+    onRequestNotificationPolicyAccess: (String) -> Unit
+) {
+    val dndSyncToPhone by viewModel.syncToPhone.collectAsState(false)
+    SwitchPreference(
+        text = stringResource(R.string.pref_dnd_sync_to_phone_title),
+        secondaryText = stringResource(R.string.pref_dnd_sync_to_phone_summary),
+        isChecked = dndSyncToPhone,
+        onCheckChanged = {
+            if ((it && viewModel.hasNotificationPolicyAccess) || !it) {
+                viewModel.setSyncToPhone(it)
+            } else {
+                onRequestNotificationPolicyAccess(DND_SYNC_TO_PHONE_KEY)
+            }
+        }
+    )
+}
+
+@ExperimentalCoroutinesApi
+@ExperimentalMaterialApi
+@Composable
+fun SyncWithTheaterSetting(
+    viewModel: DnDSyncSettingsViewModel,
+    onRequestNotificationPolicyAccess: (String) -> Unit
+) {
+    val dndSyncWithTheater by viewModel.syncWithTheater.collectAsState(false)
+    SwitchPreference(
+        text = stringResource(R.string.pref_dnd_sync_with_theater_title),
+        secondaryText = stringResource(R.string.pref_dnd_sync_with_theater_summary),
+        isChecked = dndSyncWithTheater,
+        onCheckChanged = {
+            if ((it && viewModel.hasNotificationPolicyAccess) || !it) {
+                viewModel.setSyncWithTheater(it)
+            } else {
+                onRequestNotificationPolicyAccess(DND_SYNC_WITH_THEATER_KEY)
+            }
+        }
+    )
 }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
@@ -5,19 +5,29 @@ import android.app.NotificationManager
 import androidx.core.content.getSystemService
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.boswelja.smartwatchextensions.common.connection.Capability
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.DND_SYNC_TO_PHONE_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.DND_SYNC_TO_WATCH_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.DND_SYNC_WITH_THEATER_KEY
 import com.boswelja.smartwatchextensions.watchmanager.WatchManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 
 @ExperimentalCoroutinesApi
 class DnDSyncSettingsViewModel(application: Application) : AndroidViewModel(application) {
 
     private val notificationManager = application.getSystemService<NotificationManager>()
-
     val watchManager = WatchManager.getInstance(application)
+    private val capabilities = watchManager.getCapabilitesForSelectedWatch()
+
+    val canSendDnD = capabilities.mapLatest {
+        it?.contains(Capability.SEND_DND.name) == true
+    }
+    val canReceiveDnD = capabilities.mapLatest {
+        it?.contains(Capability.RECEIVE_DND.name) == true
+    }
+
     val syncToPhone = watchManager.getBoolSetting(DND_SYNC_TO_PHONE_KEY)
     val syncToWatch = watchManager.getBoolSetting(DND_SYNC_TO_WATCH_KEY)
     val syncWithTheater = watchManager.getBoolSetting(DND_SYNC_WITH_THEATER_KEY)

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
@@ -15,10 +15,19 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 
 @ExperimentalCoroutinesApi
-class DnDSyncSettingsViewModel(application: Application) : AndroidViewModel(application) {
+class DnDSyncSettingsViewModel internal constructor(
+    application: Application,
+    val watchManager: WatchManager,
+    private val notificationManager: NotificationManager
+) : AndroidViewModel(application) {
 
-    private val notificationManager = application.getSystemService<NotificationManager>()
-    val watchManager = WatchManager.getInstance(application)
+    @Suppress("unused")
+    constructor(application: Application) : this(
+        application,
+        WatchManager.getInstance(application),
+        application.getSystemService<NotificationManager>()!!
+    )
+
     private val capabilities = watchManager.selectedWatchCapabilities()
 
     val canSendDnD = capabilities.mapLatest {
@@ -33,7 +42,7 @@ class DnDSyncSettingsViewModel(application: Application) : AndroidViewModel(appl
     val syncWithTheater = watchManager.getBoolSetting(DND_SYNC_WITH_THEATER_KEY)
 
     val hasNotificationPolicyAccess: Boolean
-        get() = notificationManager?.isNotificationPolicyAccessGranted == true
+        get() = notificationManager.isNotificationPolicyAccessGranted
 
     fun setSyncToPhone(isEnabled: Boolean) {
         viewModelScope.launch {

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
@@ -1,20 +1,29 @@
 package com.boswelja.smartwatchextensions.dndsync.ui
 
 import android.app.Application
+import android.app.NotificationManager
+import androidx.core.content.getSystemService
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.DND_SYNC_TO_PHONE_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.DND_SYNC_TO_WATCH_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.DND_SYNC_WITH_THEATER_KEY
 import com.boswelja.smartwatchextensions.watchmanager.WatchManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 
+@ExperimentalCoroutinesApi
 class DnDSyncSettingsViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val notificationManager = application.getSystemService<NotificationManager>()
 
     val watchManager = WatchManager.getInstance(application)
     val syncToPhone = watchManager.getBoolSetting(DND_SYNC_TO_PHONE_KEY)
     val syncToWatch = watchManager.getBoolSetting(DND_SYNC_TO_WATCH_KEY)
     val syncWithTheater = watchManager.getBoolSetting(DND_SYNC_WITH_THEATER_KEY)
+
+    val hasNotificationPolicyAccess: Boolean
+        get() = notificationManager?.isNotificationPolicyAccessGranted == true
 
     fun setSyncToPhone(isEnabled: Boolean) {
         viewModelScope.launch {

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
@@ -22,10 +22,10 @@ class DnDSyncSettingsViewModel(application: Application) : AndroidViewModel(appl
     private val capabilities = watchManager.selectedWatchCapabilities()
 
     val canSendDnD = capabilities.mapLatest {
-        it?.contains(Capability.SEND_DND.name) == true
+        it.contains(Capability.SEND_DND)
     }
     val canReceiveDnD = capabilities.mapLatest {
-        it?.contains(Capability.RECEIVE_DND.name) == true
+        it.contains(Capability.RECEIVE_DND)
     }
 
     val syncToPhone = watchManager.getBoolSetting(DND_SYNC_TO_PHONE_KEY)

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModel.kt
@@ -19,7 +19,7 @@ class DnDSyncSettingsViewModel(application: Application) : AndroidViewModel(appl
 
     private val notificationManager = application.getSystemService<NotificationManager>()
     val watchManager = WatchManager.getInstance(application)
-    private val capabilities = watchManager.getCapabilitesForSelectedWatch()
+    private val capabilities = watchManager.selectedWatchCapabilities()
 
     val canSendDnD = capabilities.mapLatest {
         it?.contains(Capability.SEND_DND.name) == true

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/watchinfo/ui/WatchInfoViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/watchinfo/ui/WatchInfoViewModel.kt
@@ -12,12 +12,12 @@ import androidx.lifecycle.viewModelScope
 import com.boswelja.smartwatchextensions.common.connection.Capability
 import com.boswelja.smartwatchextensions.watchmanager.WatchManager
 import com.boswelja.watchconnection.core.Watch
+import java.util.UUID
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import java.util.UUID
 
 class WatchInfoViewModel internal constructor(
     application: Application,
@@ -58,15 +58,11 @@ class WatchInfoViewModel internal constructor(
         }
     }
 
-    fun getCapabilities(): LiveData<Array<Capability>> {
+    @ExperimentalCoroutinesApi
+    fun getCapabilities(): LiveData<List<Capability>> {
         return watch.switchMap { watch ->
             watch?.let {
-                watchManager.getCapabilitiesFor(it)
-                    ?.mapNotNull { capabilities ->
-                        capabilities.map { capability ->
-                            Capability.valueOf(capability)
-                        }.toTypedArray()
-                    }?.asLiveData()
+                watchManager.getCapabilitiesFor(it)?.asLiveData()
             } ?: liveData { }
         }
     }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/watchmanager/WatchManager.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/watchmanager/WatchManager.kt
@@ -194,7 +194,7 @@ class WatchManager internal constructor(
     fun getCapabilitiesFor(watch: Watch) = connectionClient.getCapabilitiesFor(watch)
 
     @ExperimentalCoroutinesApi
-    fun getCapabilitesForSelectedWatch() =
+    fun selectedWatchCapabilities() =
         _selectedWatch.flatMapLatest<Watch?, Array<String>?> { watch ->
             watch?.let {
                 connectionClient.getCapabilitiesFor(watch)

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/watchmanager/WatchManager.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/watchmanager/WatchManager.kt
@@ -193,6 +193,14 @@ class WatchManager internal constructor(
 
     fun getCapabilitiesFor(watch: Watch) = connectionClient.getCapabilitiesFor(watch)
 
+    @ExperimentalCoroutinesApi
+    fun getCapabilitesForSelectedWatch() =
+        _selectedWatch.flatMapLatest<Watch?, Array<String>?> { watch ->
+            watch?.let {
+                connectionClient.getCapabilitiesFor(watch)
+            } ?: flow { emit(null) }
+        }
+
     suspend fun sendMessage(watch: Watch, message: String, data: ByteArray? = null) =
         connectionClient.sendMessage(watch, message, data)
 

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -211,6 +211,9 @@
     <string name="noti_channel_dnd_sync_title">Do not Disturb Sync</string>
     <string name="noti_channel_boot_or_update_title">Boot &amp; App Update Handler</string>
 
+    <!-- Capability strings -->
+    <string name="capability_not_supported">Your watch has indicated it does not support this feature</string>
+
     <string name="button_undo">Undo</string>
     <string name="button_done">Done</string>
     <string name="button_retry">Try Again</string>

--- a/mobile/src/test/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModelTest.kt
+++ b/mobile/src/test/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModelTest.kt
@@ -38,7 +38,7 @@ class BatterySyncViewModelTest {
     @get:Rule val taskExecutorRule = InstantTaskExecutorRule()
 
     private val dummyWatch = Watch("Name", "id", "platform")
-    private val dummyCapabilities = MutableStateFlow<Array<String>>(emptyArray())
+    private val dummyCapabilities = MutableStateFlow<List<Capability>>(emptyList())
     private val dummyWatchLive = MutableLiveData(dummyWatch)
     private val testDispatcher = TestCoroutineDispatcher()
 
@@ -50,9 +50,11 @@ class BatterySyncViewModelTest {
     fun setUp() {
         MockKAnnotations.init(this)
 
-        runBlocking { dummyCapabilities.emit(emptyArray()) }
+        runBlocking { dummyCapabilities.emit(emptyList()) }
 
+        every { watchManager.selectedWatchCapabilities() } returns dummyCapabilities
         every { watchManager.selectedWatch } returns dummyWatchLive
+
         viewModel = BatterySyncViewModel(
             ApplicationProvider.getApplicationContext(),
             watchManager,
@@ -99,7 +101,7 @@ class BatterySyncViewModelTest {
     @Test
     fun `canSyncBattery flows true when capability is present`(): Unit = runBlocking {
         // Emulate capability presence
-        dummyCapabilities.emit(arrayOf(Capability.SYNC_BATTERY.name))
+        dummyCapabilities.emit(listOf(Capability.SYNC_BATTERY))
 
         // Check canSyncBattery
         viewModel.canSyncBattery.take(1).collect {
@@ -110,7 +112,7 @@ class BatterySyncViewModelTest {
     @Test
     fun `canSyncBattery flows false when capability is missing`(): Unit = runBlocking {
         // Emulate capability missing
-        dummyCapabilities.emit(emptyArray())
+        dummyCapabilities.emit(emptyList())
 
         // Check canSyncBattery
         viewModel.canSyncBattery.take(1).collect {

--- a/mobile/src/test/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModelTest.kt
+++ b/mobile/src/test/kotlin/com/boswelja/smartwatchextensions/dndsync/ui/DnDSyncSettingsViewModelTest.kt
@@ -1,0 +1,107 @@
+package com.boswelja.smartwatchextensions.dndsync.ui
+
+import android.app.NotificationManager
+import android.os.Build
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.boswelja.smartwatchextensions.common.connection.Capability
+import com.boswelja.smartwatchextensions.watchmanager.WatchManager
+import com.boswelja.watchconnection.core.Watch
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class DnDSyncSettingsViewModelTest {
+
+    @get:Rule
+    val taskExecutorRule = InstantTaskExecutorRule()
+
+    private val dummyWatch = Watch("Name", "id", "platform")
+    private val dummyCapabilities = MutableStateFlow<List<Capability>>(emptyList())
+    private val dummyWatchLive = MutableLiveData(dummyWatch)
+
+    @RelaxedMockK
+    private lateinit var watchManager: WatchManager
+    @RelaxedMockK
+    private lateinit var notificationManager: NotificationManager
+
+    private lateinit var viewModel: DnDSyncSettingsViewModel
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        runBlocking { dummyCapabilities.emit(emptyList()) }
+
+        every { watchManager.selectedWatchCapabilities() } returns dummyCapabilities
+        every { watchManager.selectedWatch } returns dummyWatchLive
+
+        viewModel = DnDSyncSettingsViewModel(
+            ApplicationProvider.getApplicationContext(),
+            watchManager,
+            notificationManager
+        )
+    }
+
+    @Test
+    fun `canSendDnD flows true when capability is present`(): Unit = runBlocking {
+        // Emulate capability presence
+        dummyCapabilities.emit(listOf(Capability.SEND_DND))
+
+        // Check canSyncBattery
+        viewModel.canSendDnD.take(1).collect {
+            expectThat(it).isTrue()
+        }
+    }
+
+    @Test
+    fun `canSendDnD flows false when capability is missing`(): Unit = runBlocking {
+        // Emulate capability presence
+        dummyCapabilities.emit(emptyList())
+
+        // Check canSyncBattery
+        viewModel.canSendDnD.take(1).collect {
+            expectThat(it).isFalse()
+        }
+    }
+
+    @Test
+    fun `canReceiveDnD flows true when capability is present`(): Unit = runBlocking {
+        // Emulate capability presence
+        dummyCapabilities.emit(listOf(Capability.RECEIVE_DND))
+
+        // Check canSyncBattery
+        viewModel.canReceiveDnD.take(1).collect {
+            expectThat(it).isTrue()
+        }
+    }
+
+    @Test
+    fun `canReceiveDnD flows false when capability is missing`(): Unit = runBlocking {
+        // Emulate capability presence
+        dummyCapabilities.emit(emptyList())
+
+        // Check canSyncBattery
+        viewModel.canReceiveDnD.take(1).collect {
+            expectThat(it).isFalse()
+        }
+    }
+}

--- a/mobile/src/test/kotlin/com/boswelja/smartwatchextensions/watchinfo/ui/WatchInfoViewModelTest.kt
+++ b/mobile/src/test/kotlin/com/boswelja/smartwatchextensions/watchinfo/ui/WatchInfoViewModelTest.kt
@@ -79,7 +79,7 @@ class WatchInfoViewModelTest {
     fun `getCapabilities calls watchManager if watch is not null`(): Unit = runBlocking {
         // Mock capabilities from WatchManager
         every { watchManager.getCapabilitiesFor(any()) } returns flow {
-            emit(Capability.values().map { it.name }.toTypedArray())
+            emit(Capability.values().toList())
         }
 
         // Check with no / invalid watch selected


### PR DESCRIPTION
We've been detecting capabilities of watches for a while now, and only reporting them in individual watch info screens.
This commit currently adds a check to both DnD Sync and Battery Sync for whether the selected watch is capable of these features, and sets setting enabled state accordingly.