### PR TITLE
Remove battery Sync interval setting

### DIFF
--- a/common/src/main/kotlin/com/boswelja/smartwatchextensions/common/preference/PreferenceKey.kt
+++ b/common/src/main/kotlin/com/boswelja/smartwatchextensions/common/preference/PreferenceKey.kt
@@ -5,7 +5,6 @@ object PreferenceKey {
     const val PHONE_LOCKING_ENABLED_KEY = "lock_phone_enabled"
 
     const val BATTERY_SYNC_ENABLED_KEY = "battery_sync_enabled"
-    const val BATTERY_SYNC_INTERVAL_KEY = "battery_sync_interval"
     const val BATTERY_PHONE_CHARGE_NOTI_KEY = "battery_phone_charge_noti"
     const val BATTERY_WATCH_CHARGE_NOTI_KEY = "battery_watch_charge_noti"
     const val BATTERY_CHARGE_THRESHOLD_KEY = "battery_charge_threshold"

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/BatterySyncWorker.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/BatterySyncWorker.kt
@@ -8,15 +8,11 @@ import androidx.work.PeriodicWorkRequest
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
-import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_SYNC_INTERVAL_KEY
 import com.boswelja.smartwatchextensions.watchmanager.WatchManager
-import com.boswelja.smartwatchextensions.watchmanager.database.WatchSettingsDatabase
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class BatterySyncWorker(appContext: Context, workerParams: WorkerParameters) :
@@ -35,29 +31,25 @@ class BatterySyncWorker(appContext: Context, workerParams: WorkerParameters) :
     }
 
     companion object {
+        private const val SYNC_INTERVAL_MINUTES = 15L
         private const val EXTRA_WATCH_ID: String = "extra_watch_id"
 
         /** Starts a battery sync worker for the watch with a given ID. */
-        suspend fun startWorker(context: Context, watchId: UUID): Boolean {
+        fun startWorker(context: Context, watchId: UUID): Boolean {
             Timber.d("Starting BatterySyncWorker for %s", watchId)
-            return withContext(Dispatchers.IO) {
-                val database = WatchSettingsDatabase.getInstance(context)
-                val syncIntervalMinutes = database.intSettings()
-                    .get(watchId, BATTERY_SYNC_INTERVAL_KEY).firstOrNull()?.value ?: 15
-                val data = Data.Builder().putString(EXTRA_WATCH_ID, watchId.toString()).build()
-                val request = PeriodicWorkRequestBuilder<BatterySyncWorker>(
-                    syncIntervalMinutes.toLong(), TimeUnit.MINUTES,
-                    PeriodicWorkRequest.MIN_PERIODIC_FLEX_MILLIS, TimeUnit.MILLISECONDS
-                ).apply {
-                    setInputData(data)
-                }.build()
-                WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                    "$watchId-batterysync",
-                    ExistingPeriodicWorkPolicy.REPLACE,
-                    request
-                )
-                return@withContext true
-            }
+            val data = Data.Builder().putString(EXTRA_WATCH_ID, watchId.toString()).build()
+            val request = PeriodicWorkRequestBuilder<BatterySyncWorker>(
+                SYNC_INTERVAL_MINUTES, TimeUnit.MINUTES,
+                PeriodicWorkRequest.MIN_PERIODIC_FLEX_MILLIS, TimeUnit.MILLISECONDS
+            ).apply {
+                setInputData(data)
+            }.build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                "$watchId-batterysync",
+                ExistingPeriodicWorkPolicy.REPLACE,
+                request
+            )
+            return true
         }
 
         /** Stops the battery sync worker for the watch with a given ID. */

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsScreen.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncSettingsScreen.kt
@@ -53,10 +53,6 @@ fun BatterySyncSettings(
 
     val canSyncBattery by viewModel.canSyncBattery.collectAsState(false)
     val batterySyncEnabled by viewModel.batterySyncEnabled.collectAsState(false)
-    val syncInterval by viewModel.syncInterval.collectAsState(15)
-    var currentInterval by remember {
-        mutableStateOf(syncInterval / 100f)
-    }
 
     Column(modifier) {
         HeaderItem(stringResource(R.string.category_battery_sync_settings))
@@ -70,19 +66,6 @@ fun BatterySyncSettings(
                 viewModel.setBatterySyncEnabled(it)
             },
             isEnabled = canSyncBattery
-        )
-        SliderPreference(
-            text = stringResource(R.string.battery_sync_interval_title),
-            value = currentInterval,
-            valueRange = 0.15f..0.60f,
-            trailingFormat = stringResource(R.string.battery_sync_interval),
-            isEnabled = batterySyncEnabled,
-            onSliderValueChanged = {
-                currentInterval = it
-            },
-            onSliderValueFinished = {
-                viewModel.setSyncInterval((currentInterval * 100).toInt())
-            }
         )
     }
 }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
@@ -12,7 +12,6 @@ import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_PHONE_CHARGE_NOTI_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_PHONE_LOW_NOTI_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_SYNC_ENABLED_KEY
-import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_SYNC_INTERVAL_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_WATCH_CHARGE_NOTI_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_WATCH_LOW_NOTI_KEY
 import com.boswelja.smartwatchextensions.watchmanager.WatchManager
@@ -44,7 +43,6 @@ class BatterySyncViewModel internal constructor(
         WatchBatteryStatsDatabase.getInstance(application)
 
     val batterySyncEnabled = watchManager.getBoolSetting(BATTERY_SYNC_ENABLED_KEY)
-    val syncInterval = watchManager.getIntSetting(BATTERY_SYNC_INTERVAL_KEY)
     val phoneChargeNotiEnabled = watchManager.getBoolSetting(BATTERY_PHONE_CHARGE_NOTI_KEY)
     val watchChargeNotiEnabled = watchManager.getBoolSetting(BATTERY_WATCH_CHARGE_NOTI_KEY)
     val chargeThreshold = watchManager.getIntSetting(BATTERY_CHARGE_THRESHOLD_KEY)
@@ -84,19 +82,6 @@ class BatterySyncViewModel internal constructor(
                     getApplication(), selectedWatch.id
                 )
             }
-        }
-    }
-
-    fun setSyncInterval(syncInterval: Int) {
-        viewModelScope.launch(dispatcher) {
-            val selectedWatch = watchManager.selectedWatch.first()
-            watchManager.updatePreference(
-                selectedWatch!!, BATTERY_SYNC_INTERVAL_KEY, syncInterval
-            )
-            BatterySyncWorker
-                .stopWorker(getApplication(), selectedWatch.id)
-            BatterySyncWorker
-                .startWorker(getApplication(), selectedWatch.id)
         }
     }
 

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/bootorupdate/updater/Updater.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/bootorupdate/updater/Updater.kt
@@ -6,7 +6,10 @@ import android.content.Context
 import com.boswelja.smartwatchextensions.BuildConfig
 import com.boswelja.smartwatchextensions.appStateStore
 import com.boswelja.smartwatchextensions.appmanager.AppCacheUpdateWorker
+import com.boswelja.smartwatchextensions.batterysync.BatterySyncWorker
+import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_SYNC_ENABLED_KEY
 import com.boswelja.smartwatchextensions.watchmanager.database.WatchDatabase
+import com.boswelja.smartwatchextensions.watchmanager.database.WatchSettingsDatabase
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -37,6 +40,21 @@ class Updater(private val context: Context) {
                         AppCacheUpdateWorker.enqueueWorkerFor(context, watch.id)
                     }
                 }
+            return Result.COMPLETED
+        }
+        // Restart Battery Sync workers to ensure the correct interval is set
+        if (lastAppVersion <= 402011) {
+            val database = WatchSettingsDatabase.getInstance(context)
+            database
+                .boolSettings().getByKey(BATTERY_SYNC_ENABLED_KEY).take(1)
+                .map { settings -> settings.filter { it.value }.map { it.watchId } }
+                .collect { watchIds ->
+                    watchIds.forEach { id ->
+                        BatterySyncWorker.startWorker(context, id)
+                        BatterySyncWorker.startWorker(context, id)
+                    }
+                }
+            database.intSettings().deleteByKey("battery_sync_interval")
             return Result.COMPLETED
         }
         return Result.NOT_NEEDED

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/watchmanager/database/IntSettingDao.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/watchmanager/database/IntSettingDao.kt
@@ -20,6 +20,9 @@ interface IntSettingDao {
     @Query("SELECT * FROM int_preferences WHERE pref_key = :key")
     fun getByKey(key: String): Flow<List<IntSetting>>
 
+    @Query("DELETE FROM int_preferences WHERE pref_key = :key")
+    suspend fun deleteByKey(key: String)
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun update(intPreference: IntSetting)
 

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -20,7 +20,6 @@
     <!-- Battery Sync preference strings -->
     <string name="battery_sync_title">Battery Sync</string>
     <string name="battery_sync_toggle_title">Enable Battery Sync</string>
-    <string name="battery_sync_interval_title">Sync Interval</string>
     <string name="battery_sync_phone_charge_noti_title">Phone Charged Notification</string>
     <string name="battery_sync_phone_charge_noti_summary">Get a notification on your watch when your phone is %s%% charged</string>
     <string name="battery_sync_watch_charge_noti_title">Watch Charged Notification</string>


### PR DESCRIPTION
Most users don't seem to even touch the slider, since all it does is reduce the accuracy of battery info.