### PR TITLE
Quick Settings tiles

### DIFF
--- a/changelogs/whatsnew-en-GB
+++ b/changelogs/whatsnew-en-GB
@@ -1,12 +1,2 @@
 Additions:
-Separation Alerts! Now you can get notified when you leave a device behind
-
-Changes:
-We've redesigned the dashboard, making it easier to get an overview of all the features you've enabled
-
-Removals:
-Removed Battery Sync Interval setting. Battery Sync will now run at it's default 15 minute intervals
-
-Fixes:
-Fixed a crash that was occurring rather frequently on a majority of smartwatches
-Fixed updater not finishing in some cases
+Quick Settings tile for watch battery!

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -148,6 +148,7 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/widget_watch_battery_metadata" />
         </receiver>
+
         <activity
             android:name=".batterysync.widget.config.BatteryWidgetConfigActivity"
             android:label="@string/widget_watch_battery_config_title"
@@ -156,5 +157,19 @@
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".batterysync.quicksettings.WatchBatteryTileService"
+            android:label="@string/widget_watch_battery_title"
+            android:icon="@drawable/battery_full"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
+        </service>
+
     </application>
 </manifest>

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -162,7 +162,8 @@
             android:name=".batterysync.quicksettings.WatchBatteryTileService"
             android:label="@string/widget_watch_battery_title"
             android:icon="@drawable/battery_full"
-            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/AppSettings.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/AppSettings.kt
@@ -18,7 +18,8 @@ val Context.appSettingsStore: DataStore<Settings> by dataStore(
 class AppSettingsSerializer : Serializer<Settings> {
     override val defaultValue = Settings(
         true,
-        Settings.Theme.FOLLOW_SYSTEM
+        Settings.Theme.FOLLOW_SYSTEM,
+        ""
     )
 
     override suspend fun readFrom(input: InputStream): Settings {

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsScreen.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.outlined.Widgets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -37,7 +36,9 @@ import com.boswelja.smartwatchextensions.managespace.ui.ManageSpaceActivity
 import com.boswelja.smartwatchextensions.watchmanager.ui.WatchManagerActivity
 import com.boswelja.smartwatchextensions.widget.ui.WidgetSettingsActivity
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@ExperimentalCoroutinesApi
 @ExperimentalMaterialApi
 @Composable
 fun AppSettingsScreen() {
@@ -45,6 +46,8 @@ fun AppSettingsScreen() {
         AppSettings()
         Divider()
         AnalyticsSettings()
+        Divider()
+        QSTileSettings()
         Divider()
         WatchSettings()
     }
@@ -56,21 +59,8 @@ fun AppSettings() {
     Column {
         val viewModel: AppSettingsViewModel = viewModel()
         val context = LocalContext.current
-        val appThemeOptions = remember {
-            arrayOf(
-                Pair(context.getString(R.string.app_theme_light), Settings.Theme.LIGHT),
-                Pair(context.getString(R.string.app_theme_dark), Settings.Theme.DARK),
-                Pair(
-                    context.getString(R.string.app_theme_follow_system),
-                    Settings.Theme.FOLLOW_SYSTEM
-                )
-            )
-        }
         val currentAppTheme by viewModel.appTheme
             .collectAsState(Settings.Theme.FOLLOW_SYSTEM, Dispatchers.IO)
-        val currentThemeOption = appThemeOptions.first {
-            it.second == currentAppTheme
-        }
 
         ListItem(
             text = { Text(stringResource(R.string.noti_settings_title)) },
@@ -105,14 +95,26 @@ fun AppSettings() {
         )
         DialogPreference(
             text = stringResource(R.string.app_theme_title),
-            secondaryText = currentThemeOption.first,
+            secondaryText = when (currentAppTheme) {
+                Settings.Theme.LIGHT -> stringResource(R.string.app_theme_light)
+                Settings.Theme.DARK -> stringResource(R.string.app_theme_dark)
+                Settings.Theme.FOLLOW_SYSTEM -> stringResource(R.string.app_theme_follow_system)
+            },
             icon = if (currentAppTheme == Settings.Theme.DARK)
                 Icons.Outlined.DarkMode
             else
                 Icons.Outlined.LightMode,
-            values = appThemeOptions,
-            value = currentThemeOption,
-            onValueChanged = { viewModel.setAppTheme(it.second) }
+            values = Settings.Theme.values().toList(),
+            value = currentAppTheme,
+            onValueChanged = { viewModel.setAppTheme(it) },
+            valueLabel = {
+                val text = when (it) {
+                    Settings.Theme.LIGHT -> stringResource(R.string.app_theme_light)
+                    Settings.Theme.DARK -> stringResource(R.string.app_theme_dark)
+                    Settings.Theme.FOLLOW_SYSTEM -> stringResource(R.string.app_theme_follow_system)
+                }
+                Text(text)
+            }
         )
     }
 }
@@ -130,6 +132,33 @@ fun AnalyticsSettings() {
             isChecked = analyticsEnabled,
             onCheckChanged = {
                 viewModel.setAnalyticsEnabled(it)
+            }
+        )
+    }
+}
+
+@ExperimentalCoroutinesApi
+@ExperimentalMaterialApi
+@Composable
+fun QSTileSettings(
+    modifier: Modifier = Modifier
+) {
+    val viewModel: AppSettingsViewModel = viewModel()
+    val registeredWatches by viewModel.registeredWatches.collectAsState(emptyList(), Dispatchers.IO)
+    val qsTilesWatch by viewModel.qsTilesWatch.collectAsState(null, Dispatchers.IO)
+    Column(modifier) {
+        HeaderItem(stringResource(R.string.category_qstiles))
+        DialogPreference(
+            icon = Icons.Outlined.Watch,
+            text = stringResource(R.string.qstiles_selected_watch),
+            secondaryText = qsTilesWatch?.name,
+            values = registeredWatches,
+            value = qsTilesWatch,
+            onValueChanged = {
+                viewModel.setQSTilesWatch(it!!)
+            },
+            valueLabel = {
+                Text(it?.name ?: stringResource(R.string.watch_status_error))
             }
         )
     }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsViewModel.kt
@@ -8,23 +8,41 @@ import androidx.lifecycle.viewModelScope
 import com.boswelja.smartwatchextensions.analytics.Analytics
 import com.boswelja.smartwatchextensions.appsettings.Settings
 import com.boswelja.smartwatchextensions.appsettings.appSettingsStore
+import com.boswelja.smartwatchextensions.watchmanager.WatchManager
+import com.boswelja.watchconnection.core.Watch
+import java.util.UUID
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 class AppSettingsViewModel internal constructor(
     application: Application,
     private val dataStore: DataStore<Settings>,
-    private val analytics: Analytics
+    private val analytics: Analytics,
+    private val watchManager: WatchManager
 ) : AndroidViewModel(application) {
 
     val analyticsEnabled = dataStore.data.map { it.analyticsEnabled }
     val appTheme = dataStore.data.map { it.appTheme }
+    val registeredWatches = watchManager.registeredWatches
+    @ExperimentalCoroutinesApi
+    val qsTilesWatch = dataStore.data.map {
+        it.qsTileWatchId
+    }.flatMapLatest { idString ->
+        if (idString.isNotEmpty()) {
+            watchManager.getWatchById(UUID.fromString(idString))
+        } else {
+            watchManager.registeredWatches.map { it.firstOrNull() }
+        }
+    }
 
     @Suppress("unused")
     constructor(application: Application) : this(
         application,
         application.appSettingsStore,
-        Analytics()
+        Analytics(),
+        WatchManager.getInstance(application)
     )
 
     fun setAnalyticsEnabled(analyticsEnabled: Boolean) {
@@ -48,6 +66,14 @@ class AppSettingsViewModel internal constructor(
                     Settings.Theme.DARK -> AppCompatDelegate.MODE_NIGHT_YES
                 }
             )
+        }
+    }
+
+    fun setQSTilesWatch(watch: Watch) {
+        viewModelScope.launch {
+            dataStore.updateData {
+                it.copy(qsTileWatchId = watch.id.toString())
+            }
         }
     }
 }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.boswelja.smartwatchextensions.analytics.Analytics
 import com.boswelja.smartwatchextensions.appsettings.Settings
 import com.boswelja.smartwatchextensions.appsettings.appSettingsStore
+import com.boswelja.smartwatchextensions.batterysync.quicksettings.WatchBatteryTileService
 import com.boswelja.smartwatchextensions.watchmanager.WatchManager
 import com.boswelja.watchconnection.core.Watch
 import java.util.UUID
@@ -74,6 +75,8 @@ class AppSettingsViewModel internal constructor(
             dataStore.updateData {
                 it.copy(qsTileWatchId = watch.id.toString())
             }
+
+            WatchBatteryTileService.requestTileUpdate(getApplication())
         }
     }
 }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/Utils.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/Utils.kt
@@ -10,6 +10,7 @@ import com.boswelja.smartwatchextensions.NotificationChannelHelper
 import com.boswelja.smartwatchextensions.R
 import com.boswelja.smartwatchextensions.batterysync.database.WatchBatteryStats.Companion.toWatchBatteryStats
 import com.boswelja.smartwatchextensions.batterysync.database.WatchBatteryStatsDatabase
+import com.boswelja.smartwatchextensions.batterysync.quicksettings.WatchBatteryTileService
 import com.boswelja.smartwatchextensions.common.batterysync.BatteryStats
 import com.boswelja.smartwatchextensions.common.batterysync.References.BATTERY_STATUS_PATH
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_CHARGED_NOTI_SENT
@@ -128,6 +129,9 @@ object Utils {
 
             // Update battery stat widgets
             BaseWidgetProvider.updateWidgets(context)
+
+            // Update QS Tile
+            WatchBatteryTileService.requestTileUpdate(context)
         }
     }
 

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/quicksettings/WatchBatteryTileService.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/quicksettings/WatchBatteryTileService.kt
@@ -54,20 +54,34 @@ class WatchBatteryTileService : TileService() {
         // Do a one-shot update
         coroutineScope.launch {
             val watch = getWatch()
+            if (watch == null) {
+                // Couldn't get watch, set an error
+                updateTile {
+                    label = getString(R.string.widget_watch_battery_title)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        subtitle = getString(R.string.watch_status_error)
+                    }
+                    icon = Icon.createWithResource(
+                        this@WatchBatteryTileService, R.drawable.battery_unknown
+                    )
+                }
+                return@launch
+            }
+
             val batteryStats = WatchBatteryStatsDatabase.getInstance(this@WatchBatteryTileService)
                 .batteryStatsDao()
-                .getStats(watch?.id)
+                .getStats(watch.id)
                 .first()
 
             updateTile {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     label = getString(R.string.battery_percent, batteryStats.percent.toString())
-                    subtitle = watch?.name
+                    subtitle = watch.name
                 } else {
                     label = getString(
                         R.string.battery_percent_qs_tile_fallback,
                         batteryStats.percent.toString(),
-                        watch?.name
+                        watch.name
                     )
                 }
                 icon = Icon.createWithResource(

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/quicksettings/WatchBatteryTileService.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/quicksettings/WatchBatteryTileService.kt
@@ -63,6 +63,7 @@ class WatchBatteryTileService : TileService() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                         subtitle = getString(R.string.watch_status_error)
                     }
+                    state = Tile.STATE_UNAVAILABLE
                     icon = Icon.createWithResource(
                         this@WatchBatteryTileService, R.drawable.battery_unknown
                     )
@@ -95,6 +96,7 @@ class WatchBatteryTileService : TileService() {
                             watch.name
                         )
                     }
+                    state = Tile.STATE_ACTIVE
                     icon = Icon.createWithResource(
                         this@WatchBatteryTileService, getBatteryDrawable(batteryStats.percent)
                     )
@@ -107,6 +109,7 @@ class WatchBatteryTileService : TileService() {
                     } else {
                         label = getString(R.string.battery_sync_disabled)
                     }
+                    state = Tile.STATE_INACTIVE
                     icon = Icon.createWithResource(
                         this@WatchBatteryTileService, R.drawable.battery_unknown
                     )

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/quicksettings/WatchBatteryTileService.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/quicksettings/WatchBatteryTileService.kt
@@ -6,35 +6,17 @@ import android.content.Intent
 import android.graphics.drawable.Icon
 import android.os.Build
 import android.service.quicksettings.Tile
-import android.service.quicksettings.TileService
 import com.boswelja.smartwatchextensions.R
-import com.boswelja.smartwatchextensions.appsettings.appSettingsStore
 import com.boswelja.smartwatchextensions.batterysync.database.WatchBatteryStatsDatabase
 import com.boswelja.smartwatchextensions.batterysync.ui.BatterySyncSettingsActivity
+import com.boswelja.smartwatchextensions.common.WatchTileService
 import com.boswelja.smartwatchextensions.common.getBatteryDrawable
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_SYNC_ENABLED_KEY
-import com.boswelja.smartwatchextensions.watchmanager.WatchManager
 import com.boswelja.smartwatchextensions.watchmanager.database.WatchSettingsDatabase
 import com.boswelja.watchconnection.core.Watch
-import java.util.UUID
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 
-class WatchBatteryTileService : TileService() {
-
-    private val coroutineScope = CoroutineScope(Dispatchers.IO)
-
-    override fun onTileAdded() {
-        updateTileData()
-    }
-
-    override fun onStartListening() {
-        updateTileData()
-    }
+class WatchBatteryTileService : WatchTileService() {
 
     override fun onClick() {
         val intent = Intent(this, BatterySyncSettingsActivity::class.java).apply {
@@ -49,105 +31,66 @@ class WatchBatteryTileService : TileService() {
         }
     }
 
-    /**
-     * Collects battery stats for the configured watch, and updates the tile data.
-     */
-    private fun updateTileData() {
-        // Do a one-shot update
-        coroutineScope.launch {
-            val watch = getWatch()
-            if (watch == null) {
-                // Couldn't get watch, set an error
-                updateTile {
-                    label = getString(R.string.widget_watch_battery_title)
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        subtitle = getString(R.string.watch_status_error)
-                    }
-                    state = Tile.STATE_UNAVAILABLE
-                    icon = Icon.createWithResource(
-                        this@WatchBatteryTileService, R.drawable.battery_unknown
-                    )
+    override suspend fun onTileUpdateRequest(watch: Watch?) {
+        if (watch == null) {
+            // Couldn't get watch, set an error
+            updateTile {
+                label = getString(R.string.widget_watch_battery_title)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    subtitle = getString(R.string.watch_status_error)
                 }
-                return@launch
+                state = Tile.STATE_UNAVAILABLE
+                icon = Icon.createWithResource(
+                    this@WatchBatteryTileService, R.drawable.battery_unknown
+                )
             }
+            return
+        }
 
-            val isBatterySyncEnabled = WatchSettingsDatabase
+        val isBatterySyncEnabled = WatchSettingsDatabase
+            .getInstance(this@WatchBatteryTileService)
+            .boolSettings()
+            .get(watch.id, BATTERY_SYNC_ENABLED_KEY)
+            .first()
+            ?.value ?: false
+
+        if (isBatterySyncEnabled) {
+            val batteryStats = WatchBatteryStatsDatabase
                 .getInstance(this@WatchBatteryTileService)
-                .boolSettings()
-                .get(watch.id, BATTERY_SYNC_ENABLED_KEY)
+                .batteryStatsDao()
+                .getStats(watch.id)
                 .first()
-                ?.value ?: false
 
-            if (isBatterySyncEnabled) {
-                val batteryStats = WatchBatteryStatsDatabase
-                    .getInstance(this@WatchBatteryTileService)
-                    .batteryStatsDao()
-                    .getStats(watch.id)
-                    .first()
-
-                updateTile {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        label = getString(R.string.battery_percent, batteryStats.percent.toString())
-                        subtitle = watch.name
-                    } else {
-                        label = getString(
-                            R.string.battery_percent_qs_tile_fallback,
-                            batteryStats.percent.toString(),
-                            watch.name
-                        )
-                    }
-                    state = Tile.STATE_ACTIVE
-                    icon = Icon.createWithResource(
-                        this@WatchBatteryTileService, getBatteryDrawable(batteryStats.percent)
+            updateTile {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    label = getString(R.string.battery_percent, batteryStats.percent.toString())
+                    subtitle = watch.name
+                } else {
+                    label = getString(
+                        R.string.battery_percent_qs_tile_fallback,
+                        batteryStats.percent.toString(),
+                        watch.name
                     )
                 }
-            } else {
-                updateTile {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        label = getString(R.string.widget_watch_battery_title)
-                        subtitle = getString(R.string.battery_sync_disabled)
-                    } else {
-                        label = getString(R.string.battery_sync_disabled)
-                    }
-                    state = Tile.STATE_INACTIVE
-                    icon = Icon.createWithResource(
-                        this@WatchBatteryTileService, R.drawable.battery_unknown
-                    )
-                }
+                state = Tile.STATE_ACTIVE
+                icon = Icon.createWithResource(
+                    this@WatchBatteryTileService, getBatteryDrawable(batteryStats.percent)
+                )
             }
-        }
-    }
-
-    /**
-     * Try to get the watch attached to QS Tiles.
-     * @return The watch attached to QS tiles, or null if not found.
-     */
-    private suspend fun getWatch(): Watch? {
-        val watchId = appSettingsStore.data.map { it.qsTileWatchId }.first()
-        val watchManager = WatchManager.getInstance(this)
-        return if (watchId.isNotBlank()) {
-            val id = UUID.fromString(watchId)
-            watchManager.getWatchById(id).firstOrNull()
         } else {
-            val watch = WatchManager.getInstance(this)
-                .registeredWatches
-                .first()
-                .firstOrNull()
-
-            if (watch != null) {
-                appSettingsStore.updateData { it.copy(qsTileWatchId = watch.id.toString()) }
+            updateTile {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    label = getString(R.string.widget_watch_battery_title)
+                    subtitle = getString(R.string.battery_sync_disabled)
+                } else {
+                    label = getString(R.string.battery_sync_disabled)
+                }
+                state = Tile.STATE_INACTIVE
+                icon = Icon.createWithResource(
+                    this@WatchBatteryTileService, R.drawable.battery_unknown
+                )
             }
-            watch
         }
-    }
-
-    /**
-     * A convenience function for updating the tile's data.
-     */
-    private fun updateTile(updates: Tile.() -> Unit) {
-        qsTile.apply {
-            updates()
-        }.also { it.updateTile() }
     }
 
     companion object {

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/quicksettings/WatchBatteryTileService.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/quicksettings/WatchBatteryTileService.kt
@@ -1,0 +1,122 @@
+package com.boswelja.smartwatchextensions.batterysync.quicksettings
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import com.boswelja.smartwatchextensions.R
+import com.boswelja.smartwatchextensions.appsettings.appSettingsStore
+import com.boswelja.smartwatchextensions.batterysync.database.WatchBatteryStatsDatabase
+import com.boswelja.smartwatchextensions.batterysync.ui.BatterySyncSettingsActivity
+import com.boswelja.smartwatchextensions.common.getBatteryDrawable
+import com.boswelja.smartwatchextensions.watchmanager.WatchManager
+import com.boswelja.watchconnection.core.Watch
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+class WatchBatteryTileService : TileService() {
+
+    private val coroutineScope = CoroutineScope(Dispatchers.IO)
+
+    override fun onTileAdded() {
+        updateTileData()
+    }
+
+    override fun onStartListening() {
+        updateTileData()
+    }
+
+    override fun onClick() {
+        val intent = Intent(this, BatterySyncSettingsActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        if (isLocked) {
+            unlockAndRun {
+                startActivityAndCollapse(intent)
+            }
+        } else {
+            startActivityAndCollapse(intent)
+        }
+    }
+
+    /**
+     * Collects battery stats for the configured watch, and updates the tile data.
+     */
+    private fun updateTileData() {
+        // Do a one-shot update
+        coroutineScope.launch {
+            val watch = getWatch()
+            val batteryStats = WatchBatteryStatsDatabase.getInstance(this@WatchBatteryTileService)
+                .batteryStatsDao()
+                .getStats(watch?.id)
+                .first()
+
+            updateTile {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    label = getString(R.string.battery_percent, batteryStats.percent.toString())
+                    subtitle = watch?.name
+                } else {
+                    label = getString(
+                        R.string.battery_percent_qs_tile_fallback,
+                        batteryStats.percent.toString(),
+                        watch?.name
+                    )
+                }
+                icon = Icon.createWithResource(
+                    this@WatchBatteryTileService, getBatteryDrawable(batteryStats.percent)
+                )
+            }
+        }
+    }
+
+    /**
+     * Try to get the watch attached to QS Tiles.
+     * @return The watch attached to QS tiles, or null if not found.
+     */
+    private suspend fun getWatch(): Watch? {
+        val watchId = appSettingsStore.data.map { it.qsTileWatchId }.first()
+        val watchManager = WatchManager.getInstance(this)
+        return if (watchId.isNotBlank()) {
+            val id = UUID.fromString(watchId)
+            watchManager.getWatchById(id).firstOrNull()
+        } else {
+            val watch = WatchManager.getInstance(this)
+                .registeredWatches
+                .first()
+                .firstOrNull()
+
+            if (watch != null) {
+                appSettingsStore.updateData { it.copy(qsTileWatchId = watch.id.toString()) }
+            }
+            watch
+        }
+    }
+
+    /**
+     * A convenience function for updating the tile's data.
+     */
+    private fun updateTile(updates: Tile.() -> Unit) {
+        qsTile.apply {
+            updates()
+        }.also { it.updateTile() }
+    }
+
+    companion object {
+        /**
+         * Request this QS Tile updates it's data.
+         */
+        fun requestTileUpdate(context: Context) {
+            requestListeningState(
+                context, ComponentName(context, WatchBatteryTileService::class.java)
+            )
+        }
+    }
+}

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/batterysync/ui/BatterySyncViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.boswelja.smartwatchextensions.batterysync.BatterySyncWorker
 import com.boswelja.smartwatchextensions.batterysync.Utils.updateBatteryStats
 import com.boswelja.smartwatchextensions.batterysync.database.WatchBatteryStatsDatabase
+import com.boswelja.smartwatchextensions.batterysync.quicksettings.WatchBatteryTileService
 import com.boswelja.smartwatchextensions.common.connection.Capability
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_CHARGE_THRESHOLD_KEY
 import com.boswelja.smartwatchextensions.common.preference.PreferenceKey.BATTERY_LOW_THRESHOLD_KEY
@@ -81,6 +82,7 @@ class BatterySyncViewModel internal constructor(
                 BatterySyncWorker.stopWorker(
                     getApplication(), selectedWatch.id
                 )
+                WatchBatteryTileService.requestTileUpdate(getApplication())
             }
         }
     }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/common/Battery.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/common/Battery.kt
@@ -1,5 +1,6 @@
 package com.boswelja.smartwatchextensions.common
 
+import androidx.annotation.DrawableRes
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,7 +16,17 @@ fun BatteryIcon(
     percent: Int,
     modifier: Modifier = Modifier
 ) {
-    val drawable = when (percent) {
+    val drawable = getBatteryDrawable(percent)
+    Icon(
+        painterResource(drawable),
+        null,
+        modifier
+    )
+}
+
+@DrawableRes
+fun getBatteryDrawable(percent: Int): Int {
+    return when (percent) {
         in 0..20 -> R.drawable.battery_alert
         in 20..30 -> R.drawable.battery_20
         in 30..40 -> R.drawable.battery_30
@@ -28,11 +39,6 @@ fun BatteryIcon(
         100 -> R.drawable.battery_full
         else -> R.drawable.battery_unknown
     }
-    Icon(
-        painterResource(drawable),
-        null,
-        modifier
-    )
 }
 
 private class BatteryPercentProvider : PreviewParameterProvider<Int> {

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/common/WatchTileService.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/common/WatchTileService.kt
@@ -1,0 +1,82 @@
+package com.boswelja.smartwatchextensions.common
+
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import com.boswelja.smartwatchextensions.appsettings.appSettingsStore
+import com.boswelja.smartwatchextensions.watchmanager.WatchManager
+import com.boswelja.watchconnection.core.Watch
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * An abstract implementation of [TileService] that provides the watch tied to QS Tiles, as well as
+ * a coroutine wrapper.
+ */
+abstract class WatchTileService : TileService() {
+
+    private val coroutineScope = CoroutineScope(Dispatchers.IO)
+    private var coroutineJob: Job? = null
+
+    /**
+     * Called when a tile update is requested.
+     * @param watch The [Watch] tied to QS Tiles, or null if none was found.
+     */
+    abstract suspend fun onTileUpdateRequest(watch: Watch?)
+
+    override fun onTileAdded() {
+        coroutineJob = coroutineScope.launch {
+            val watch = getWatch()
+            onTileUpdateRequest(watch)
+        }
+    }
+
+    override fun onStartListening() {
+        coroutineJob = coroutineScope.launch {
+            val watch = getWatch()
+            onTileUpdateRequest(watch)
+        }
+    }
+
+    override fun onTileRemoved() {
+        // Cancel any running jobs
+        coroutineJob?.cancel()
+    }
+
+    /**
+     * Try to get the watch attached to QS Tiles.
+     * @return The watch attached to QS tiles, or null if not found.
+     */
+    private suspend fun getWatch(): Watch? {
+        val watchId = appSettingsStore.data.map { it.qsTileWatchId }.first()
+        val watchManager = WatchManager.getInstance(this)
+        return if (watchId.isNotBlank()) {
+            val id = UUID.fromString(watchId)
+            watchManager.getWatchById(id).firstOrNull()
+        } else {
+            val watch = WatchManager.getInstance(this)
+                .registeredWatches
+                .first()
+                .firstOrNull()
+
+            if (watch != null) {
+                appSettingsStore.updateData { it.copy(qsTileWatchId = watch.id.toString()) }
+            }
+            watch
+        }
+    }
+
+    /**
+     * A convenience function for updating the tile's data.
+     */
+    fun updateTile(updates: Tile.() -> Unit) {
+        qsTile.apply {
+            updates()
+        }.also { it.updateTile() }
+    }
+}

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/common/ui/Preferences.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/common/ui/Preferences.kt
@@ -123,9 +123,10 @@ fun <T> DialogPreference(
     secondaryText: String? = null,
     icon: ImageVector? = null,
     isEnabled: Boolean = true,
-    values: Array<Pair<String, T>>,
-    value: Pair<String, T>,
-    onValueChanged: (Pair<String, T>) -> Unit
+    values: List<T>,
+    value: T,
+    onValueChanged: (T) -> Unit,
+    valueLabel: @Composable (T) -> Unit
 ) {
     var dialogVisible by remember { mutableStateOf(false) }
     ListItem(
@@ -142,10 +143,10 @@ fun <T> DialogPreference(
                 LazyColumn {
                     items(values) { item ->
                         ListItem(
-                            text = { Text(item.first) },
+                            text = { valueLabel(item) },
                             icon = {
                                 RadioButton(
-                                    selected = item.second == selectedValue.second,
+                                    selected = item == selectedValue,
                                     onClick = null
                                 )
                             },

--- a/mobile/src/main/proto/settings.proto
+++ b/mobile/src/main/proto/settings.proto
@@ -13,4 +13,6 @@ message Settings {
 
   bool analyticsEnabled = 1;
   Theme appTheme = 2;
+
+  string qsTileWatchId = 3;
 }

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -105,6 +105,8 @@
     <string name="manage_watches_title">Manage Watches</string>
     <string name="category_analytics">Analytics</string>
     <string name="analytics_enabled_title">Send Anonymous Usage Stats</string>
+    <string name="category_qstiles">Quick Settings</string>
+    <string name="qstiles_selected_watch">Linked Watch</string>
 
     <string name="widget_watch_battery_title">Watch Battery</string>
     <string name="widget_watch_battery_config_title">Watch Battery Widget Setup</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -227,6 +227,8 @@
     <!-- Capability strings -->
     <string name="capability_not_supported">Your watch has indicated it does not support this feature</string>
 
+    <!-- QS Tile strings -->
+    <string name="battery_percent_qs_tile_fallback">%s%% (%s)</string>
     <string name="button_undo">Undo</string>
     <string name="button_done">Done</string>
     <string name="button_next">Continue</string>


### PR DESCRIPTION
This PR adds `WatchTileService`, along with related infrastructure to create Quick Settings Tiles.
I've also created a tile for watch battery to start with.
Due to limitations with Quick Settings tiles, we can effectively only have one tile per type. I've worked around this by allowing the user to choose a specific watch for QS Tiles to use for data.
This resolves #183 