### PR TITLE
Updater rework

### DIFF
--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/AppSettings.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/AppSettings.kt
@@ -19,7 +19,8 @@ class AppSettingsSerializer : Serializer<Settings> {
     override val defaultValue = Settings(
         true,
         Settings.Theme.FOLLOW_SYSTEM,
-        ""
+        "",
+        false
     )
 
     override suspend fun readFrom(input: InputStream): Settings {

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsScreen.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsScreen.kt
@@ -61,6 +61,7 @@ fun AppSettings() {
         val context = LocalContext.current
         val currentAppTheme by viewModel.appTheme
             .collectAsState(Settings.Theme.FOLLOW_SYSTEM, Dispatchers.IO)
+        val checkUpdatesDaily by viewModel.checkUpdatesDaily.collectAsState(false, Dispatchers.IO)
 
         ListItem(
             text = { Text(stringResource(R.string.noti_settings_title)) },
@@ -115,6 +116,11 @@ fun AppSettings() {
                 }
                 Text(text)
             }
+        )
+        CheckboxPreference(
+            text = stringResource(R.string.check_updates_daily_title),
+            isChecked = checkUpdatesDaily,
+            onCheckChanged = viewModel::setCheckUpdatesDaily
         )
     }
 }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsScreen.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.outlined.DarkMode
 import androidx.compose.material.icons.outlined.LightMode
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material.icons.outlined.Update
 import androidx.compose.material.icons.outlined.Watch
 import androidx.compose.material.icons.outlined.Widgets
 import androidx.compose.runtime.Composable
@@ -119,6 +120,7 @@ fun AppSettings() {
         )
         CheckboxPreference(
             text = stringResource(R.string.check_updates_daily_title),
+            icon = Icons.Outlined.Update,
             isChecked = checkUpdatesDaily,
             onCheckChanged = viewModel::setCheckUpdatesDaily
         )

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsViewModel.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/appsettings/ui/AppSettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.boswelja.smartwatchextensions.analytics.getAnalytics
 import com.boswelja.smartwatchextensions.appsettings.Settings
 import com.boswelja.smartwatchextensions.appsettings.appSettingsStore
 import com.boswelja.smartwatchextensions.batterysync.quicksettings.WatchBatteryTileService
+import com.boswelja.smartwatchextensions.updatechecker.UpdateCheckWorker
 import com.boswelja.smartwatchextensions.watchmanager.WatchManager
 import com.boswelja.watchconnection.core.Watch
 import java.util.UUID
@@ -38,6 +39,7 @@ class AppSettingsViewModel internal constructor(
             watchManager.registeredWatches.map { it.firstOrNull() }
         }
     }
+    val checkUpdatesDaily = dataStore.data.map { it.checkForUpdates }
 
     @Suppress("unused")
     constructor(application: Application) : this(
@@ -78,6 +80,19 @@ class AppSettingsViewModel internal constructor(
             }
 
             WatchBatteryTileService.requestTileUpdate(getApplication())
+        }
+    }
+
+    fun setCheckUpdatesDaily(newValue: Boolean) {
+        viewModelScope.launch {
+            dataStore.updateData {
+                it.copy(checkForUpdates = newValue)
+            }
+            if (newValue) {
+                UpdateCheckWorker.schedule(getApplication())
+            } else {
+                UpdateCheckWorker.cancel(getApplication())
+            }
         }
     }
 }

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/updatechecker/GooglePlayUpdateChecker.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/updatechecker/GooglePlayUpdateChecker.kt
@@ -1,0 +1,29 @@
+package com.boswelja.smartwatchextensions.updatechecker
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.model.UpdateAvailability
+import com.google.android.play.core.ktx.requestAppUpdateInfo
+
+/**
+ * An [UpdateChecker] that checks Google Play for available updates.
+ */
+class GooglePlayUpdateChecker(context: Context) : UpdateChecker {
+
+    private val updateManager = AppUpdateManagerFactory.create(context)
+
+    override suspend fun isNewVersionAvailable(): Boolean {
+        val updateInfo = updateManager.requestAppUpdateInfo()
+        return updateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+    }
+
+    override fun launchDownloadScreen(context: Context) {
+        val intent = Intent(
+            Intent.ACTION_VIEW,
+            Uri.parse("market://details?id=com.boswelja.smartwatchextensions")
+        )
+        context.startActivity(intent)
+    }
+}

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/updatechecker/UpdateCheckWorker.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/updatechecker/UpdateCheckWorker.kt
@@ -1,0 +1,66 @@
+package com.boswelja.smartwatchextensions.updatechecker
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.boswelja.smartwatchextensions.R
+import com.boswelja.smartwatchextensions.messages.Message
+import com.boswelja.smartwatchextensions.messages.Priority
+import com.boswelja.smartwatchextensions.messages.sendMessage
+import java.util.concurrent.TimeUnit
+
+/**
+ * A [CoroutineWorker] to handle checking for updates and notifying the user.
+ */
+class UpdateCheckWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result {
+        val updater = GooglePlayUpdateChecker(applicationContext)
+        if (updater.isNewVersionAvailable()) {
+            val message = Message(
+                icon = Message.Icon.UPDATE,
+                title = applicationContext.getString(R.string.update_available_title),
+                text = applicationContext.getString(R.string.update_available_text),
+                action = Message.Action.INSTALL_UPDATE
+            )
+            applicationContext.sendMessage(message, Priority.HIGH)
+        }
+        return Result.success()
+    }
+
+    companion object {
+        private const val WorkerName = "update-checker"
+
+        /**
+         * Schedule the [UpdateCheckWorker] to be run daily with constraints.
+         */
+        fun schedule(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .setRequiresBatteryNotLow(true)
+                .build()
+            val request = PeriodicWorkRequestBuilder<UpdateCheckWorker>(1, TimeUnit.DAYS)
+                .setConstraints(constraints)
+                .build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WorkerName,
+                ExistingPeriodicWorkPolicy.REPLACE,
+                request
+            )
+        }
+
+        /**
+         * Cancel any scheduled [UpdateCheckWorker].
+         */
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WorkerName)
+        }
+    }
+}

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/updatechecker/UpdateChecker.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/updatechecker/UpdateChecker.kt
@@ -2,6 +2,10 @@ package com.boswelja.smartwatchextensions.updatechecker
 
 import android.content.Context
 
+fun getUpdateChecker(context: Context): UpdateChecker {
+    return GooglePlayUpdateChecker(context)
+}
+
 /**
  * An interface for a basic app update checker.
  */

--- a/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/updatechecker/UpdateChecker.kt
+++ b/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/updatechecker/UpdateChecker.kt
@@ -1,0 +1,21 @@
+package com.boswelja.smartwatchextensions.updatechecker
+
+import android.content.Context
+
+/**
+ * An interface for a basic app update checker.
+ */
+interface UpdateChecker {
+
+    /**
+     * Checks whether a new version is available.
+     * @return true if a new app version is available, false otherwise.
+     */
+    suspend fun isNewVersionAvailable(): Boolean
+
+    /**
+     * Starts the update flow.
+     * @param context The [Context] that's requesting the launch.
+     */
+    fun launchDownloadScreen(context: Context)
+}

--- a/mobile/src/main/proto/settings.proto
+++ b/mobile/src/main/proto/settings.proto
@@ -15,4 +15,6 @@ message Settings {
   Theme appTheme = 2;
 
   string qsTileWatchId = 3;
+
+  bool checkForUpdates = 4;
 }

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -209,6 +209,7 @@
     <!-- Update checker strings -->
     <string name="update_available_title">Update available</string>
     <string name="update_available_text">A new version of Smartwatch Extensions is available</string>
+    <string name="check_updates_daily_title">Check for Updates Daily</string>
 
     <!-- Donate strings -->
     <string name="donate_fetching_options">Fetching available donations…</string>


### PR DESCRIPTION
Moved update checker logic out of MainActivity. This should lead to slightly better startup performance.
Update checking is now opt-in, and can be toggled from within app settings.
Update check functions have been abstracted to the UpdateChecker interface, so we can swap checkers easier later on