### PR TITLE
Update WatchConnectionLib to version 7.0.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.0-alpha04")
+        classpath("com.android.tools.build:gradle:7.2.0-alpha05")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("com.google.gms:google-services:4.3.10")
         classpath("com.squareup.wire:wire-gradle-plugin:${libs.versions.wire.get()}")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ strikt = "0.31.0"
 sqldelight = "1.5.0"
 timber = "4.7.1"
 turbine = "0.6.1"
-watchconnection = "7.0.1"
+watchconnection = "7.0.3"
 wire = "3.7.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ strikt = "0.31.0"
 sqldelight = "1.5.0"
 timber = "4.7.1"
 turbine = "0.6.1"
-watchconnection = "7.0.3"
+watchconnection = "7.0.4"
 wire = "3.7.0"
 
 [libraries]


### PR DESCRIPTION
This fixes multiple bugs, specifically background receivers not working on Wear OS and onboarding crashing on Wear OS