### PR TITLE
fix: Replace deprecated stopForeground usages

### DIFF
--- a/dndsync/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/LocalDnDCollectorService.kt
+++ b/dndsync/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/LocalDnDCollectorService.kt
@@ -99,7 +99,7 @@ class LocalDnDCollectorService : BaseLocalDnDCollectorService() {
     /** Stops the service if it doesn't need to be running any more. */
     private fun stopIfUnneeded() {
         if (targetWatches.isEmpty()) {
-            stopForeground(true)
+            stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
         }
     }

--- a/dndsync/wear/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/LocalDnDAndTheaterCollectorService.kt
+++ b/dndsync/wear/src/main/kotlin/com/boswelja/smartwatchextensions/dndsync/LocalDnDAndTheaterCollectorService.kt
@@ -144,7 +144,7 @@ class LocalDnDAndTheaterCollectorService : BaseLocalDnDCollectorService() {
      */
     private fun tryStop(): Boolean {
         if (!dndSyncToPhone && !dndSyncWithTheater) {
-            stopForeground(true)
+            stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
             return true
         }

--- a/proximity/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/proximity/SeparationObserverService.kt
+++ b/proximity/mobile/src/main/kotlin/com/boswelja/smartwatchextensions/proximity/SeparationObserverService.kt
@@ -123,7 +123,7 @@ class SeparationObserverService : LifecycleService() {
 
     private fun tryStop() {
         statusCollectorJob?.cancel()
-        stopForeground(true)
+        stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
 

--- a/proximity/wear/src/main/kotlin/com/boswelja/smartwatchextensions/proximity/SeparationObserverService.kt
+++ b/proximity/wear/src/main/kotlin/com/boswelja/smartwatchextensions/proximity/SeparationObserverService.kt
@@ -121,7 +121,7 @@ class SeparationObserverService : LifecycleService() {
     }
 
     private fun tryStop() {
-        stopForeground(true)
+        stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
 


### PR DESCRIPTION
`stopForeground(Boolean)` is deprecated. Its usages should be replaced with `stopForeground(Int)`